### PR TITLE
Replacing gcr with docker registry for the buildpacks that participate

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -1,39 +1,39 @@
 description = "Ubuntu 22.04 Jammy Jellyfish base image with buildpacks for Java, Go, .NET Core, Node.js, Python, Apache HTTPD, NGINX and Procfile"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/dotnet-core:1.5.0"
+  uri = "docker://docker.io/paketobuildpacks/dotnet-core:1.5.0"
   version = "1.5.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/go:4.15.0"
+  uri = "docker://docker.io/paketobuildpacks/go:4.15.0"
   version = "4.15.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/java-native-image:11.9.0"
+  uri = "docker://docker.io/paketobuildpacks/java-native-image:11.9.0"
   version = "11.9.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/java:18.5.0"
+  uri = "docker://docker.io/paketobuildpacks/java:18.5.0"
   version = "18.5.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/nodejs:7.5.0"
+  uri = "docker://docker.io/paketobuildpacks/nodejs:7.5.0"
   version = "7.5.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/procfile:5.11.0"
+  uri = "docker://docker.io/paketobuildpacks/procfile:5.11.0"
   version = "5.11.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/python:2.25.0"
+  uri = "docker://docker.io/paketobuildpacks/python:2.25.0"
   version = "2.25.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/ruby:0.47.6"
+  uri = "docker://docker.io/paketobuildpacks/ruby:0.47.6"
   version = "0.47.6"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/web-servers:1.3.0"
+  uri = "docker://docker.io/paketobuildpacks/web-servers:1.3.0"
   version = "1.3.0"
 
 [lifecycle]

--- a/smoke/testdata/dotnet/README.md
+++ b/smoke/testdata/dotnet/README.md
@@ -2,7 +2,7 @@
 
 ## Building
 
-`pack build dotnet-runtime-sample --buildpack gcr.io/paketo-buildpacks/dotnet-core`
+`pack build dotnet-runtime-sample --buildpack docker.io/paketobuildpacks/dotnet-core`
 
 ## Running
 

--- a/smoke/testdata/go/README.md
+++ b/smoke/testdata/go/README.md
@@ -2,7 +2,7 @@
 
 ## Building
 
-`pack build mod-sample --buildpack gcr.io/paketo-buildpacks/go`
+`pack build mod-sample --buildpack docker.io/paketobuildpacks/go`
 
 ## Running
 

--- a/smoke/testdata/httpd/README.md
+++ b/smoke/testdata/httpd/README.md
@@ -3,7 +3,7 @@
 ## Building
 
 ```bash
-pack build my-httpd-app --buildpack gcr.io/paketo-buildpacks/httpd --builder paketobuildpacks/builder:full
+pack build my-httpd-app --buildpack docker.io/paketobuildpacks/httpd --builder paketobuildpacks/builder:full
 ```
 
 ## Running

--- a/smoke/testdata/nginx/README.md
+++ b/smoke/testdata/nginx/README.md
@@ -3,7 +3,7 @@
 ## Building
 
 ```bash
-pack build my-nginx-app --buildpack gcr.io/paketo-buildpacks/nginx
+pack build my-nginx-app --buildpack docker.io/paketobuildpacks/nginx
 ```
 
 ## Running

--- a/smoke/testdata/nodejs/README.md
+++ b/smoke/testdata/nodejs/README.md
@@ -2,7 +2,7 @@
 
 ## Building
 
-`pack build npm-sample --buildpack gcr.io/paketo-buildpacks/nodejs`
+`pack build npm-sample --buildpack docker.io/paketobuildpacks/nodejs`
 
 ## Running
 

--- a/smoke/testdata/python/README.md
+++ b/smoke/testdata/python/README.md
@@ -2,7 +2,7 @@
 
 ## Building
 
-`pack build pipenv-sample --buildpack gcr.io/paketo-buildpacks/python`
+`pack build pipenv-sample --buildpack docker.io/paketobuildpacks/python`
 
 ## Running
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR alters the registry that the buildpacks are getting pulled from, from GCR to Docker.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
